### PR TITLE
Add line comment support

### DIFF
--- a/settings/language-viml.cson
+++ b/settings/language-viml.cson
@@ -1,0 +1,3 @@
+'.source.viml':
+  'editor':
+    'commentStart': '" '


### PR DESCRIPTION
When you comment out a line with `Ctrl-/` or `Command-/`, a `"` will be
appended instead of wrapping the line with `/* */` by default.